### PR TITLE
refactor: move randomUUID to Crypto

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
     <p>
       This specification describes an API for generating character encoded
       Universally Unique Identifiers (UUID) based on [[RFC4122]], available
-      as a global method on <code><dfn data-cite="!HTML#window">Window</dfn></code>
-      and <code><dfn data-cite="!HTML#workerglobalscope">WorkerGlobalScope</dfn></code>
-      objects.
+      as a method on the
+      <code><dfn data-cite="WebCryptoAPI/#dfn-Crypto">Crypto</dfn></code>
+      interface.
     </p>
   </section>
   <section id='sotd'>
@@ -85,14 +85,15 @@
 
   <section>
     <h2>Description</h2>
-    <section data-dfn-for="WindowOrWorkerGlobalScope">
-      <h3>Extensions to the <code>WindowOrWorkerGlobalScope</code> interface</h3>
+    <section data-dfn-for="Crypto">
+      <h3>Extensions to the <code>Crypto</code> interface</h3>
       <p>
-        This document extends the <code><dfn data-cite="!HTML#windoworworkerglobalscope">WindowOrWorkerGlobalScope</dfn></code>
-        interface defined by [[!HTML]].
+        The <dfn data-cite="WebCryptoAPI/#dfn-Crypto">Crypto</dfn> interface is
+        defined in [[!WebCryptoAPI]].
       </p>
       <pre class="idl">
-        partial interface mixin WindowOrWorkerGlobalScope {
+        [Exposed=(Window,Worker)]
+        partial interface mixin <dfn id="dfn-Crypto"></dfn>Crypto</dfn> {
           DOMString randomUUID();
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
       </p>
       <pre class="idl">
         [Exposed=(Window,Worker)]
-        partial interface mixin <dfn id="dfn-Crypto"></dfn>Crypto</dfn> {
+        partial interface <dfn id="dfn-Crypto"></dfn>Crypto</dfn> {
           DOMString randomUUID();
         };
       </pre>


### PR DESCRIPTION
In conversation with a few people, it's been suggested to me that `crypto` is a better home for `randomUUID` than the global Window object. Given the close relationship to `Crypto.getRandomValues()` I agree with this.

Node.js chose the module crypto for their implementation in [node/36729](https://github.com/nodejs/node/pull/36729).

CC: @domenic (for advice on spec), @jasnell (to keep you in the loop).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/pull/3.html" title="Last updated on Jan 19, 2021, 8:44 PM UTC (a56fd41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/3/e17af05...a56fd41.html" title="Last updated on Jan 19, 2021, 8:44 PM UTC (a56fd41)">Diff</a>