### PR TITLE
refactor: simplify steps in algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,28 +135,19 @@
           <li>
             <p>
               Return the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a> of
-              « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[0],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[1],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[2],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[3],
-                <code>"-"</code>,
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[4],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[5],
-                <code>"-"</code>,
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[6],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[7],
-                <code>"-"</code>,
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[8],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[9],
-                <code>"-"</code>,
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[10],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[11],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[12],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[13],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[14],
-                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[15]
-              ».
-            </p>
+              « </p>
+                <ol style="list-style-type: none"></li>
+                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[0], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[1], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[2], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[3],
+                  <li><code>"-"</code>,</li>
+                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[4], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[5],</li>
+                  <li><code>"-"</code>,</li>
+                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[6], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[7],</li>
+                  <li></lio><code>"-"</code></li>
+                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[8], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[9],</li>
+                  <li><code>"-"</code>,</li>
+                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[10], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[11], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[12], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[13], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[14], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[15]</li>
+                </ol>
+              <p>».</p>
           </li>
         </ol>
         <p>

--- a/index.html
+++ b/index.html
@@ -123,73 +123,40 @@
           </li>
           <li>
             <p>
-              Let <var>timeLow</var> be the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a>
-              of « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[0],
-              <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[1], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[2], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[3] ».
+              Set the 4 most significant bits of <var>array</var>[6], which represent the UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to <code>0b0100</code>.
             </p>
           </li>
           <li>
             <p>
-              Let <var>timeMid</var> be the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a>
-              of « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[4],
-              <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[5] ».
-            </p>
-          </li>
-          <li>
-            <p>
-              Let <var>timeHighAndVersion</var> be a 4 character <a data-type="typedef" href="https://infra.spec.whatwg.org/#string">string</a>
-              populated as follows:
-            </p>
-            <ol>
-              <li>
-                <p>
-                  Set the 4 most significant bits of <var>array</var>[6], which represent the UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to <code>0b0100</code>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Set <var>timeHighAndVersion</var> be the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a>
-                  of « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[6],
-                  <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[7] ».
-                </p>
-              </li>
-            </ol>
-          </li>
-          <li>
-            <p>
-              Let <var>clockSeqAndReservedClockSeqLow</var> be a 4 character <a data-type="typedef" href="https://infra.spec.whatwg.org/#string">string</a>
-              populated as follows:
-            </p>
-            <ol>
-              <li>
-                <p>
-                  Set the 2 most significant bits of <var>array</var>[8], which
-                  represent the UUID <a data-cite="RFC4122#section-4.1.1">variant</a>,
-                  to <code>0b10</code>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Set <var>clockSeqAndReservedClockSeqLow</var> be the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a>
-                  of « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[8],
-                  <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[9] ».
-                </p>
-              </li>
-            </ol>
-          </li>
-          <li>
-            <p>
-              Let <var>node</var> be the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a>
-              of « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[10],
-              <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[11], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[12], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[13],
-              <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[14], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> <var>array</var>[15] ».
+              Set the 2 most significant bits of <var>array</var>[8], which
+              represent the UUID <a data-cite="RFC4122#section-4.1.1">variant</a>,
+              to <code>0b10</code>.
             </p>
           </li>
           <li>
             <p>
               Return the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a> of
-              « <var>timeLow</var>, <var>timeMid</var>, <var>timeHighAndVersion</var>,
-              <var>clockSeqAndReservedClockSeqLow</var>, <var>node</var> » with separator <code>"-"</code>.
+              « <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[0],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[1],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[2],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[3],
+                <code>"-"</code>,
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[4],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[5],
+                <code>"-"</code>,
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[6],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[7],
+                <code>"-"</code>,
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[8],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[9],
+                <code>"-"</code>,
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[10],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[11],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[12],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[13],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[14],
+                <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[15]
+              ».
             </p>
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -100,8 +100,7 @@
       <p class="note" role="note"><span>Note:
         <code><a href="#random-uuid" data-link-type="dfn">randomUUID()</a></code> generates a new
         <a data-cite="RFC4122#section-4.4">version 4 UUID</a> and returns its
-        <a data-cite="RFC2141#section-2.2">namespace specific string representation</a> described in
-        <a data-cite="RFC2141#section-2.2">namespace specific string</a> representation of a UUID described in
+        <a data-cite="RFC2141#section-2.2">namespace specific string representation</a> as described in
         <a data-cite="RFC4122#section-3">RFC4122</a>.
       </span>
       <section>


### PR DESCRIPTION
Follow up to #5, based on @ctavan's feedback. This simplifies the algorithm steps, moving them closer to those described in RFC4122 (_they're almost identical to his [reference implementation in Chromium](https://github.com/chromium/chromium/blob/99314be8152e688bafbbf9a615536bdbb289ea87/chrome/test/chromedriver/js/call_function.js#L49)_).

The one part I thought was a bit ugly was how giant **step 5** becomes, overall I liked this approach better though.

Fixes #9


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/pull/11.html" title="Last updated on Feb 12, 2021, 12:46 AM UTC (affe0ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/11/e99caa3...affe0ab.html" title="Last updated on Feb 12, 2021, 12:46 AM UTC (affe0ab)">Diff</a>