### PR TITLE
fix: wrong GitHub link was in spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       data: [
         {
           value: 'GitHub repository',
-          href: 'https://github.com/WICG/visual-viewport/'
+          href: 'https://github.com/WICG/uuid/'
         }
       ]
     }],


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/pull/12.html" title="Last updated on Feb 8, 2021, 9:03 PM UTC (79474d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/12/e99caa3...79474d8.html" title="Last updated on Feb 8, 2021, 9:03 PM UTC (79474d8)">Diff</a>