### PR TITLE
Editorial cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,36 @@
 
 This is the repository for uuid. You're welcome to
 [contribute](CONTRIBUTING.md)!
+
+## Implementation status
+
+ * [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1197594) - Shipping 92.
+ * [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1723674) - Work in progress.
+ * [WebKit](https://bugs.webkit.org/show_bug.cgi?id=229240) - Implemented, not shipped yet.
+
+## Usage example
+
+```JS
+const uuid = crypto.randomUUID();
+```
+## Motivation
+
+### UUID generation is a common software requirement
+
+The <a href="https://www.npmjs.com/package/uuid">uuid library</a> on npm
+currently receives 131,000,000 monthly downloads and is relied on by over
+2,600,000 repositories (as of June 2019).
+
+The ubiquitous nature of the `uuid` module demonstrates that UUID generation is a common
+requirement for JavaScript software applications, making the functionality a good candidate for the
+standard library.
+### Developers "re-inventing the wheel" is potentially harmful
+
+Developers who have not been exposed to [RFC4122] might naturally opt to invent their own approaches
+to UUID generation, potentially using `Math.random()`.
+
+There's an in-depth discussion of why a Cryptographically-Secure-Pseudo-Random-Number-Generator
+(CSPRNG) should be used when generating UUIDs. Of primary concern is that, without a high-quality source
+of randomness, collisions can frequently occur.
+
+Introducing a UUID standard library, which dictates that a CSPRNG must be used, helps protect developers from security pitfalls.

--- a/index.html
+++ b/index.html
@@ -1,15 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8">
-  <title>uuid</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-  <script class='remove'>
-  "use strict";
-  // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
-  var respecConfig = {
-    "githubAPI": "WICG/uuid",
+  <head>
+    <meta charset="utf-8">
+    <title>
+      uuid
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class=
+    "remove"></script>
+    <script class='remove'>
+    "use strict";
+    // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
+    var respecConfig = {
+    "github": "WICG/uuid",
     "editors": [{
         name: "Ben Coe",
         email: "bencoe@google.com",
@@ -29,195 +31,194 @@
         companyURL: "https://google.com",
       }
     ],
-    otherLinks: [{
-      key: 'Participation',
-      data: [
-        {
-          value: 'GitHub repository',
-          href: 'https://github.com/WICG/uuid/'
-        }
-      ]
-    }],
     "shortName": "uuid",
     "specStatus": "CG-DRAFT",
-    "group": "wicg"
-  };
-  </script>
-</head>
-
-<body>
-  <section id="abstract">
-    <p>
-      This specification describes an API for generating character encoded
-      Universally Unique Identifiers (UUID) based on [[RFC4122]], available
-      as a method on the
-      <code><dfn data-cite="WebCryptoAPI/#dfn-Crypto">Crypto</dfn></code>
-      interface.
-    </p>
-  </section>
-  <section id='sotd'>
-  </section>
-  <section id="introduction">
-    <h2>Introduction</h2>
-    <em>This section is non-normative.</em>
-    <h3 class="heading settled" data-level="1.1" id="intro">
-      <span class="secno">1.1 </span>
-      <span class="content">Motivation</span>
-      <a class="self-link" href="#intro"></a>
-    </h3>
-    <h4>UUID generation is a common software requirement</h4>
-    <p>
-      The <a href="https://www.npmjs.com/package/uuid">uuid library</a> on npm
-      currently receives 131,000,000 monthly downloads and is relied on by over
-      2,600,000 repositories (as of June 2019).
-    </p>
-    <p>
-      The ubiquitous nature of the `uuid` module demonstrates that UUID generation is a common
-      requirement for JavaScript software applications, making the functionality a good candidate for the
-      standard library.
-    </p>
-    <h4>Developers "re-inventing the wheel" is potentially harmful</h4>
-    <p>
-      Developers who have not been exposed to [[RFC4122]] might naturally opt to invent their own approaches
-      to UUID generation, potentially using <code>Math.random()</code> (in <a href="https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d">TIFU by using <code>Math.random()</code></a>
-      there's an in-depth discussion of why a Cryptographically-Secure-Pseudo-Random-Number-Generator
-      (CSPRNG) should be used when generating UUIDs. Of primary concern is that, without a high-quality source
-      of randomness, collisions can frequently occur.
-    </p>
-    <p>
-      Introducing a UUID standard library, which dictates that a CSPRNG must be used, helps protect
-      developers from security pitfalls.
-    </p>
-  </section>
-
-  <section id="conformance"></section>
-
-  <section>
-    <h2>Description</h2>
-    <section data-dfn-for="Crypto">
-      <h3>Extensions to the <code>Crypto</code> interface</h3>
+    "group": "wicg",
+    xref: "web-platform",
+    };
+    </script>
+  </head>
+  <body data-cite="webcryptoapi">
+    <section id="abstract">
       <p>
-        The <dfn data-cite="WebCryptoAPI/#dfn-Crypto">Crypto</dfn> interface is
-        defined in [[!WebCryptoAPI]].
+        This specification describes an API for generating character encoded
+        Universally Unique Identifiers (UUID) based on [[RFC4122]], available
+        as a method on the {{Crypto}} interface.
       </p>
+    </section>
+    <section id='sotd'>
+      <p>
+        This is a work in progress.
+      </p>
+    </section>
+    <section>
+      <h2>
+        Usage Example
+      </h2>
+      <p>
+        To generate a UUID, simply call the {{Crypto/randomUUID()}} method:
+      </p>
+      <pre class="example js">
+        const uuid = crypto.randomUUID();
+      </pre>
+    </section>
+    <section data-dfn-for="Crypto">
+      <h2>
+        Extensions to the `Crypto` interface
+      </h2>
       <pre class="idl">
         [Exposed=(Window,Worker)]
         partial interface Crypto {
           [SecureContext] DOMString randomUUID();
         };
       </pre>
-      <p class="note" role="note"><span>Note:
-        <code><a href="#random-uuid" data-link-type="dfn">randomUUID()</a></code> generates a new
-        <a data-cite="RFC4122#section-4.4">version 4 UUID</a> and returns its
-        <a data-cite="RFC2141#section-2.2">namespace specific string representation</a> as described in
-        <a data-cite="RFC4122#section-3">RFC4122</a>.
-      </span>
-      <section>
-        <h4>The <code class="idl"><a href="#random-uuid" data-link-type="dfn">randomUUID()</a></code> method.</h4>
-        The <dfn class="dfn-paneled idl-code" data-dfn-for="Crypto" data-dfn-type="method" data-export data-lt="randomUUID" id="random-uuid"><code>randomUUID()</code></dfn> method steps are to return the result of [=generate a random UUID|generating a random UUID=].
-
-        <p>To <dfn data-export>generate a random UUID</dfn>:</p>
-
-        <ol>
-          <li>
-            <p>
-              Let <var>array</var> be a <a data-cite="INFRA#list">list</a> with 16 elements of the type <a data-cite="INFRA#byte">byte</a>.
-            </p>
-          </li>
-          <li>
-            <p>
-              Overwrite all elements of <var>array</var> with cryptographically secure random values of
-              the type <a data-cite="INFRA#byte">byte</a>.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the 4 most significant bits of <var>array</var>[6], which represent the UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to <code>0b0100</code>.
-            </p>
-          </li>
-          <li>
-            <p>
-              Set the 2 most significant bits of <var>array</var>[8], which
-              represent the UUID <a data-cite="RFC4122#section-4.1.1">variant</a>,
-              to <code>0b10</code>.
-            </p>
-          </li>
-          <li>
-            <p>
-              Return the <a data-type="typedef" href="https://infra.spec.whatwg.org/#string-concatenate">concatenation</a> of
-              « </p>
-                <ol style="list-style-type: none">
-                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[0], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[1], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[2], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[3],
-                  <li><code>"-"</code>,</li>
-                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[4], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[5],</li>
-                  <li><code>"-"</code>,</li>
-                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[6], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[7],</li>
-                  <li><code>"-"</code></li>
-                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[8], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[9],</li>
-                  <li><code>"-"</code>,</li>
-                  <li><a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[10], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[11], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[12], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[13], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[14], <a href="#hex-representation" data-link-type="dfn">hexadecimal representation</a> of <var>array</var>[15]</li>
-                </ol>
-              <p>».</p>
-          </li>
-        </ol>
+      <aside class="note">
         <p>
-          For the steps described in the [=generate a random UUID=] algorithm,
-          the <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-lt="hexadecimal representation" id="hex-representation">hexadecimal representation</dfn>
-          of a <a data-cite="INFRA#byte">byte</a> <var>value</var> is the
-          two-character string created by expressing <var>value</var> in hexadecimal
-          using <a data-cite="INFRA#ascii-lower-hex-digit">ASCII lower hex digits</a>,
-          left-padded with <code>"0"</code> to reach two characters.
+          {{Crypto/randomUUID()}} generates a new <a data-cite=
+          "RFC4122#section-4.4">version 4 UUID</a> and returns its
+          <a data-cite="RFC2141#section-2.2">namespace specific string
+          representation</a> as described in <a data-cite=
+          "RFC4122#section-3">section 3</a> of [[RFC4122]].
+        </p>
+      </aside>
+      <section>
+        <h3>
+          The `randomUUID()` method
+        </h3>
+        <p>
+          When <dfn>randomUUID()</dfn> is called, a [=user agent=] method MUST
+          return the result of [=generate a random UUID=].
         </p>
       </section>
     </section>
-  </section>
-  <section id="security">
-    <h2>Security considerations</h2>
-    <em>This section is non-normative.</em>
-    <dl>
-      <dt>Denial of service</dt>
-      <dd>
-      Generating random values has the potential to perform computationally expensive and/or
-      blocking work (<em>if there is not enough entropy available in the system</em>).
-      As such, hostile applications may attempt to misuse this API
-      and attempt to cause significant amount of work to be performed by an
-      implementation, denying access or services to other applications that are
-      executing. In practice, these concerns can be mitigated by using
-      non-blocking sources of randomness, e.g., "/dev/urandom".
-      See also, <dfn data-cite="WebCryptoAPI/#security-considerations">WebCrypto Security Considerations</dfn>.
-      </dd>
-      <dt>Insufficient entropy</dt>
-      <dd>
-      If <code><a href="#random-uuid" data-link-type="dfn">randomUUID()</a></code> is invoked before the underlying
-      system is seeded with enough entropy it may result in colliding UUIDs (due to cycles in the PRNG).
-      Authors of applications that use <a href="#random-uuid" data-link-type="dfn">randomUUID()</a> need to be
-      aware of these risks.
-      </dd>
-    </dl>
-  </section>
-  <section id="security">
-    <h2>Privacy considerations</h2>
-    <em>This section is non-normative.</em>
-    <dl>
-      <dt>Fingerprinting</dt>
-      <dd>
-        By exposing additional APIs that reflect capabilities of the underlying
-        platform, this specification may allow malicious applications to
-        determine or distinguish different user agents or devices. One such
-        approach is outlined in
-        <a href="https://www.youtube.com/watch?v=5sZT9FTx3aQ">Clock Around the Clock: Time-Based Device Fingerprinting</a>
-        which discusses creating a fingerprint based on a PRNG in JavaScript.
-        <a href="#random-uuid" data-link-type="dfn">randomUUID()</a> is not likely to make users more susceptible to
-        fingerprinting than they are through existing cryptography methods.
-        See also, <dfn data-cite="WebCryptoAPI/#privacy">WebCrypto Privacy Considerations</dfn>.
-      </dd>
-      <dt>Use of <a href="#random-uuid" data-link-type="dfn">randomUUID()</a> as user ID</dt>
-      <dd>
-        <a href="#random-uuid" data-link-type="dfn">randomUUID()</a> is useful for generating
-        <a href="https://w3cping.github.io/privacy-threat-model/#user-id">user IDs</a>, but does not directly give any
-        ability to generate <a href="https://w3cping.github.io/privacy-threat-model/#global-identifier">global identifiers</a>.
-      </dd>
-    </dl>
-  </section>
-</body>
+    <section>
+      <h2>
+        Generating a random UUID
+      </h2>
+      <p>
+        To <dfn data-export="">generate a random UUID</dfn>:
+      </p>
+      <ol>
+        <li>Let |array| be a [=list=] with 16 elements of the type [=byte=].
+        </li>
+        <li>Overwrite all elements of |array| with cryptographically secure
+        random values of the type [=byte=].
+        </li>
+        <li>Set the 4 most significant bits of |array|[6], which represent the
+        UUID <a data-cite="RFC4122#section-4.1.3">version</a>, to `0b0100`.
+        </li>
+        <li>Set the 2 most significant bits of |array|[8], which represent the
+        UUID <a data-cite="RFC4122#section-4.1.1">variant</a>, to `0b10`.
+        </li>
+        <li>
+          <p>
+            Return the [=string/concatenate|concatenation=] of «
+          </p>
+          <ol style="list-style-type: none">
+            <li>[=hexadecimal representation=] of |array|[0], [=hexadecimal
+            representation=] of |array|[1], [=hexadecimal representation=] of
+            |array|[2], [=hexadecimal representation=] of |array|[3],
+            </li>
+            <li>`"-"`,
+            </li>
+            <li>[=hexadecimal representation=] of |array|[4], [=hexadecimal
+            representation=] of |array|[5],
+            </li>
+            <li>`"-"`,
+            </li>
+            <li>[=hexadecimal representation=] of |array|[6], [=hexadecimal
+            representation=] of |array|[7],
+            </li>
+            <li>`"-"`,
+            </li>
+            <li>[=hexadecimal representation=] of |array|[8], [=hexadecimal
+            representation=] of |array|[9],
+            </li>
+            <li>`"-"`,
+            </li>
+            <li>[=hexadecimal representation=] of |array|[10], [=hexadecimal
+            representation=] of |array|[11], [=hexadecimal representation=] of
+            |array|[12], [=hexadecimal representation=] of |array|[13],
+            [=hexadecimal representation=] of |array|[14], [=hexadecimal
+            representation=] of |array|[15]
+            </li>
+          </ol>
+          <p>
+            ».
+          </p>
+        </li>
+      </ol>
+      <p>
+        For the steps described in the [=generate a random UUID=] algorithm, the
+        <dfn>hexadecimal representation</dfn> of a [=byte=] |value| is the
+        two-character string created by expressing |value| in hexadecimal using
+        [=ASCII lower hex digits=], left-padded with `"0"` to reach two
+        [=characters=].
+      </p>
+    </section>
+    <section id="security" class="informative">
+      <h2>
+        Security considerations
+      </h2>
+      <dl>
+        <dt>
+          Denial of service
+        </dt>
+        <dd>
+          Generating random values has the potential to perform computationally
+          expensive and/or blocking work (<em>if there is not enough entropy
+          available in the system</em>). As such, hostile applications may
+          attempt to misuse this API and attempt to cause significant amount of
+          work to be performed by an implementation, denying access or services
+          to other applications that are executing. In practice, these concerns
+          can be mitigated by using non-blocking sources of randomness, e.g.,
+          "/dev/urandom". See also, <dfn data-cite=
+          "WebCryptoAPI/#security-considerations">WebCrypto Security
+          Considerations</dfn>.
+        </dd>
+        <dt>
+          Insufficient entropy
+        </dt>
+        <dd>
+          If {{Crypto/randomUUID()}} is invoked before the underlying system is
+          seeded with enough entropy it may result in colliding UUIDs (due to
+          cycles in the PRNG). Authors of applications that use
+          {{Crypto/randomUUID}} need to be aware of these risks.
+        </dd>
+      </dl>
+    </section>
+    <section id="security">
+      <h2>
+        Privacy considerations
+      </h2><em>This section is non-normative.</em>
+      <dl>
+        <dt>
+          Fingerprinting
+        </dt>
+        <dd>
+          By exposing additional APIs that reflect capabilities of the
+          underlying platform, this specification may allow malicious
+          applications to determine or distinguish different user agents or
+          devices. One such approach is outlined in <a href=
+          "https://www.youtube.com/watch?v=5sZT9FTx3aQ">Clock Around the Clock:
+          Time-Based Device Fingerprinting</a> which discusses creating a
+          fingerprint based on a PRNG in JavaScript. {{Crypto/randomUUID}} is
+          not likely to make users more susceptible to fingerprinting than they
+          are through existing cryptography methods. See also, <dfn data-cite=
+          "WebCryptoAPI/#privacy">WebCrypto Privacy Considerations</dfn>.
+        </dd>
+        <dt>
+          Use of {{Crypto/randomUUID}} as user ID
+        </dt>
+        <dd>
+          {{Crypto/randomUUID}} is useful for generating <a href=
+          "https://w3cping.github.io/privacy-threat-model/#user-id">user
+          IDs</a>, but does not directly give any ability to generate <a href=
+          "https://w3cping.github.io/privacy-threat-model/#global-identifier">global
+          identifiers</a>.
+        </dd>
+      </dl>
+    </section>
+    <section id="conformance"></section>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,30 +11,30 @@
     "use strict";
     // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
     var respecConfig = {
-    "github": "WICG/uuid",
-    "editors": [{
-        name: "Ben Coe",
-        email: "bencoe@google.com",
-        company: "Google",
-        companyURL: "https://google.com",
-      },
-      // Add additional editors here.
-      // https://github.com/w3c/respec/wiki/editors
-      {
-        name: "Robert Kieffer",
-        email: "robert@broofa.com",
-      },
-      {
-        name: "Christoph Tavan",
-        email: "ctavan@google.com",
-        company: "Google",
-        companyURL: "https://google.com",
-      }
-    ],
-    "shortName": "uuid",
-    "specStatus": "CG-DRAFT",
-    "group": "wicg",
-    xref: "web-platform",
+      "github": "WICG/uuid",
+      "editors": [{
+          name: "Ben Coe",
+          email: "bencoe@google.com",
+          company: "Google",
+          companyURL: "https://google.com",
+        },
+        // Add additional editors here.
+        // https://github.com/w3c/respec/wiki/editors
+        {
+          name: "Robert Kieffer",
+          email: "robert@broofa.com",
+        },
+        {
+          name: "Christoph Tavan",
+          email: "ctavan@google.com",
+          company: "Google",
+          companyURL: "https://google.com",
+        }
+      ],
+      "shortName": "uuid",
+      "specStatus": "CG-DRAFT",
+      "group": "wicg",
+      "xref": "web-platform",
     };
     </script>
   </head>
@@ -56,10 +56,12 @@
         Usage Example
       </h2>
       <p>
-        To generate a UUID, simply call the {{Crypto/randomUUID()}} method:
+        To generate a UUID, simply call {{Crypto}}'s {{Crypto/randomUUID()}}
+        method:
       </p>
-      <pre class="example js">
-        const uuid = crypto.randomUUID();
+      <pre class="example js" title="Generate unique name for download">
+        const filename = `${crypto.randomUUID()}.txt`;
+        // do something with filename.
       </pre>
     </section>
     <section data-dfn-for="Crypto">
@@ -149,8 +151,8 @@
         </li>
       </ol>
       <p>
-        For the steps described in the [=generate a random UUID=] algorithm, the
-        <dfn>hexadecimal representation</dfn> of a [=byte=] |value| is the
+        For the steps described in the [=generate a random UUID=] algorithm,
+        the <dfn>hexadecimal representation</dfn> of a [=byte=] |value| is the
         two-character string created by expressing |value| in hexadecimal using
         [=ASCII lower hex digits=], left-padded with `"0"` to reach two
         [=characters=].


### PR DESCRIPTION
closes #7 

Cleanups ReSpec usage and cross references. 

Makes the following editorial changes: 

* Moved motivation to README. 
* Added implementation status to README. 
* Added example to README.
* Added example from #7 to spec.
* Fixed up conformance wording for calling randomUUID()


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/uuid/pull/28.html" title="Last updated on Aug 20, 2021, 5:04 AM UTC (63b54cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/uuid/28/5f620e9...marcoscaceres:63b54cc.html" title="Last updated on Aug 20, 2021, 5:04 AM UTC (63b54cc)">Diff</a>