### PR TITLE
chore(CI): auto-publish snapshot to gh-pages

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Generate snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          TOOLCHAIN: respec
+          W3C_BUILD_OVERRIDE: |
+            status: CG-DRAFT


### PR DESCRIPTION
Closes #32 

Blocked on #33 + creating a "main" branch. 


